### PR TITLE
Fixed tables plugin not working in a non-browser context

### DIFF
--- a/src/tables.js
+++ b/src/tables.js
@@ -68,7 +68,7 @@ function isHeadingRow (tr) {
      parentNode.nodeName === 'TBODY') {
     tableNode = parentNode.parentNode
   }
-  return (tableNode.nodeName === 'TABLE' && tableNode.rows[0] === tr)
+  return (tableNode.nodeName === 'TABLE' && tableNode.querySelector('tr') === tr)
 }
 
 function cell (content, node) {


### PR DESCRIPTION
In a non-browser context (e.g. when running turndown via nodejs) turndown will use ["domino" as HTML parser](https://github.com/mixmark-io/turndown/blob/ef41a54852afefb9383a5aa0668e1054bda3cc9b/src/html-parser.js#L50-L53).

As domino does not support the "rows" property on tables, i replaced this part with a `querySelector` to check for the first table row. With this fix, the plugin runs flawless.