### PR TITLE
テーブルcellの中で<br>タグを利用できるようにする

### DIFF
--- a/src/tables.js
+++ b/src/tables.js
@@ -76,8 +76,8 @@ function cell (content, node) {
   var prefix = ' '
   if (index === 0) prefix = '| '
   // Ensure single line per cell (both windows and unix EoL)
-  // TODO: allow gfm non-strict mode to replace new lines by `<br/>`
-  content = content.replace(/\r\n/g, '\n').replace(/\n/g, ' ')
+  // 先頭・末尾の改行は、不要なスペースが挿入されるだけなので削除している
+  content = content.replace(/\r\n/g, '\n').replace(/^\n+/g, '').replace(/\n+$/g, '').replace(/\n+/g, '<br />');
   // | must be escaped as \|
   content = content.replace(/\|/g, '\\|')
   return prefix + content + ' |'


### PR DESCRIPTION
- 変更内容
- `function cell` 内部で `\n` を書き換える処理で、`<br>` を書き出すように変更した
- `.gitignore` から `lib` と `dist` を削除して、npm packageとしてダウンロードした時のように出力されたファイルをリポジトリに含めた
  - 他のプロダクトからURL指定でnpm installして参照できるようにするため